### PR TITLE
Document Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
   2. Start the app with `php -S 127.0.0.1:8000 -t /workspace /tmp/trip-router.php`.
 - Useful checks are `php -l biolink-style386.php` for the PHP template and `node --check trip-*.js` for the browser JavaScript modules.
 - There is no database, queue, or backend API service for local development; core app state is stored in browser `localStorage`.
+- Current UI add/import flows can show success while leaving dashboard data unchanged because some handlers save a cloned `TripCore` data object or reload after writing storage. For smoke tests, seed through `TripCore.importData()` before verifying dashboard, destinations, and expenses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+## Cursor Cloud specific instructions
+
+- This repo contains a single browser-based Trip Manager app. There are no package manager or Composer manifests, so the dependency refresh step is intentionally a no-op.
+- The template `biolink-style386.php` expects a parent PHP host to define `ASSETS_FULL_URL` and `TRIP_VERSION`, and it loads JavaScript from `/trip/*.js` even though the files live in the repo root. In Cursor Cloud, run it with a temporary PHP router that defines those constants and maps `/trip/` requests back to the root files.
+- Example dev-server router:
+  1. Create `/tmp/trip-router.php` with a router that serves `/trip/trip-*.js` from `$_SERVER['DOCUMENT_ROOT']`, defines `ASSETS_FULL_URL` as `/`, defines `TRIP_VERSION` as `dev_`, and includes `biolink-style386.php` for `/` and `/biolink-style386.php`.
+  2. Start the app with `php -S 127.0.0.1:8000 -t /workspace /tmp/trip-router.php`.
+- Useful checks are `php -l biolink-style386.php` for the PHP template and `node --check trip-*.js` for the browser JavaScript modules.
+- There is no database, queue, or backend API service for local development; core app state is stored in browser `localStorage`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add Cursor Cloud notes for running the Trip Manager PHP/browser app with a temporary router shim.
- Record that the repo has no installable package dependencies, uses browser localStorage, and currently needs `TripCore.importData()` for reliable smoke-test seeding.

### Validation
- Installed PHP CLI in the VM and started the app with PHP's built-in development server.
- Ran PHP and JavaScript syntax checks.
- Verified the app in Chrome with seeded trip data across dashboard, destinations, and expenses.

[trip_manager_seeded_data_clear_demo.mp4](https://cursor.com/agents/bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrip_manager_seeded_data_clear_demo.mp4)

[Seeded dashboard](https://cursor.com/agents/bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrip_manager_dashboard_seeded.webp)
[Seeded destination](https://cursor.com/agents/bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrip_manager_destination_seeded.webp)
[Seeded expense](https://cursor.com/agents/bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrip_manager_expense_seeded.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb9fffbf-bcf9-42c4-bd6d-2efe510c630f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

